### PR TITLE
simplified file naming logic

### DIFF
--- a/R/gpmodels_internal.R
+++ b/R/gpmodels_internal.R
@@ -589,14 +589,12 @@ gpm_add_predictors_internal = function(time_frame = NULL,
                 paste0('.csv'))
 } else {
   # BUGFIX truncates filename when variable name(s) exceed 30 characters
-  var_length = nchar(paste0(variables, collapse = '_'))
-  if(var_length > 30) {
-    new_var_length = (30 - path_length)
+  if(nchar(paste0(variables, collapse = '_')) > 30) {
+    var_labels = substring(paste0(variables, collapse = '_'), 0, 30)
     message("Filename truncated due to length")
-  } else (new_var_length = var_length)
+  } else var_labels = paste0(variables, collapse = '_')
   file.path(time_frame$output_folder,
-            paste0(filename_prefix, file_type, '_variables_', substring(paste0(variables, collapse = '_'), 0, new_var_length),
-                   '_', lubridate::now()) %>%
+            paste0(filename_prefix, file_type, '_variables_', var_labels, '_', lubridate::now()) %>%
               janitor::make_clean_names() %>%
               paste0('.csv'))
 }


### PR DESCRIPTION
limits variable labels to 30 characters in the filename output